### PR TITLE
記事の作成と一覧取得

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,6 +2,7 @@ import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { Module } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
 import { join } from 'path';
+import { ArticleModule } from './article/article.module';
 
 @Module({
   imports: [
@@ -11,6 +12,7 @@ import { join } from 'path';
       playground: true,
       autoSchemaFile: join(process.cwd(), 'src/schema.gql'), //コードファーストで進める際にnest.jsから自動生成されるスキーマファイルの指定
     }),
+    ArticleModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/article/article.module.ts
+++ b/backend/src/article/article.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class ArticleModule {}

--- a/backend/src/article/article.module.ts
+++ b/backend/src/article/article.module.ts
@@ -1,4 +1,7 @@
 import { Module } from '@nestjs/common';
+import { ArticleResolver } from './article.resolver';
 
-@Module({})
+@Module({
+  providers: [ArticleResolver]
+})
 export class ArticleModule {}

--- a/backend/src/article/article.module.ts
+++ b/backend/src/article/article.module.ts
@@ -1,7 +1,8 @@
 import { Module } from '@nestjs/common';
 import { ArticleResolver } from './article.resolver';
+import { ArticleService } from './article.service';
 
 @Module({
-  providers: [ArticleResolver]
+  providers: [ArticleResolver, ArticleService],
 })
 export class ArticleModule {}

--- a/backend/src/article/article.resolver.ts
+++ b/backend/src/article/article.resolver.ts
@@ -1,0 +1,4 @@
+import { Resolver } from '@nestjs/graphql';
+
+@Resolver()
+export class ArticleResolver {}

--- a/backend/src/article/article.resolver.ts
+++ b/backend/src/article/article.resolver.ts
@@ -1,4 +1,25 @@
-import { Resolver } from '@nestjs/graphql';
+import { Resolver, Mutation, Args, Query } from '@nestjs/graphql';
+import { ArticleService } from './article.service';
+import { Article } from './models/article.model';
 
-@Resolver()
-export class ArticleResolver {}
+@Resolver(() => Article)
+export class ArticleResolver {
+  constructor(private readonly articleService: ArticleService) {}
+
+  // createArticle Mutation を定義
+  @Mutation(() => Article)
+  createArticle(
+    @Args('title') title: string,
+    @Args('url') url: string,
+    @Args('description', { nullable: true }) description?: string,
+    @Args('tags', { type: () => [String], nullable: true }) tags?: string[],
+  ): Article {
+    return this.articleService.createArticle(title, url, description, tags);
+  }
+
+  // getArticles Query を定義（記事一覧取得）
+  @Query(() => [Article])
+  getArticles(): Article[] {
+    return this.articleService.getArticles();
+  }
+}

--- a/backend/src/article/article.service.ts
+++ b/backend/src/article/article.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { Article } from './models/article.model';
+
+@Injectable()
+export class ArticleService {
+  articles: Article[] = [];
+
+  // 新しい記事を作成するメソッド
+  createArticle(
+    title: string,
+    url: string,
+    description?: string,
+    tags?: string[],
+  ): Article {
+    const newArticle = new Article();
+
+    // 新しい記事のIDを自動的に付与
+    newArticle.id = this.articles.length + 1;
+    newArticle.title = title;
+    newArticle.url = url;
+    newArticle.description = description || '';
+    newArticle.tags = tags || [];
+    newArticle.createdAt = new Date();
+    newArticle.updatedAt = new Date();
+    newArticle.deletedAt = null;
+
+    // 作成した記事をarticles配列に追加
+    this.articles.push(newArticle);
+
+    return newArticle;
+  }
+
+  // 記事一覧を取得するメソッド
+  getArticles(): Article[] {
+    return this.articles;
+  }
+}

--- a/backend/src/article/models/article.model.ts
+++ b/backend/src/article/models/article.model.ts
@@ -1,0 +1,33 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class Article {
+  //TSのフィールドをGraphQLのスキーマのフィールドに変換
+  @Field(() => Int) //GraphQLの場合、先頭が大文字
+  id: number;
+
+  @Field()
+  title: string;
+
+  @Field()
+  url: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field(() => [String], { nullable: true })
+  tags?: string[];
+
+  //Userを作成後
+  //   @Field(() => User)
+  //   author: User;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+
+  @Field({ nullable: true })
+  deletedAt?: Date | null;
+}

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -1,0 +1,27 @@
+# ------------------------------------------------------
+# THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+# ------------------------------------------------------
+
+type Article {
+  id: Int!
+  title: String!
+  url: String!
+  description: String
+  tags: [String!]
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  deletedAt: DateTime
+}
+
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
+type Query {
+  getArticles: [Article!]!
+}
+
+type Mutation {
+  createArticle(title: String!, url: String!, description: String, tags: [String!]): Article!
+}


### PR DESCRIPTION
すでに1は作成済み
```
mutation {
  createArticle(
    title: "Nest.js", 
    url: "https://zenn.dev/norihashimo/articles/de0edfde59edf2", 
    description: "Nest.jsの基本概念", 
    tags: ["Nest.js", "TypeScript"]
  ) {
    id
    title
    url
    description
    tags
  }
}
```

<img width="1437" alt="スクリーンショット 2024-12-07 1 38 12" src="https://github.com/user-attachments/assets/3aabe0de-28eb-4de7-b1b9-d758b75731bb">


```
query {
  getArticles {
    id
    title
    url
    description
    tags
    createdAt
    updatedAt
    deletedAt
  }
}
```

<img width="1433" alt="スクリーンショット 2024-12-07 1 38 28" src="https://github.com/user-attachments/assets/ffd2b2b8-7074-4d26-abc0-c2d47f000658">
