### PR TITLE
タスクの作成と一覧取得

### DIFF
--- a/backend/prisma/prisma.module.ts
+++ b/backend/prisma/prisma.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/backend/prisma/prisma.service.ts
+++ b/backend/prisma/prisma.service.ts
@@ -1,0 +1,9 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit() {
+    await this.$connect();
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
 import { join } from 'path';
 import { ArticleModule } from './article/article.module';
+import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { ArticleModule } from './article/article.module';
       autoSchemaFile: join(process.cwd(), 'src/schema.gql'), //コードファーストで進める際にnest.jsから自動生成されるスキーマファイルの指定
     }),
     ArticleModule,
+    PrismaModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/article/article.module.ts
+++ b/backend/src/article/article.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ArticleResolver } from './article.resolver';
 import { ArticleService } from './article.service';
+import { PrismaModule } from '../../prisma/prisma.module';
 
 @Module({
+  imports: [PrismaModule],
   providers: [ArticleResolver, ArticleService],
 })
 export class ArticleModule {}

--- a/backend/src/article/article.resolver.ts
+++ b/backend/src/article/article.resolver.ts
@@ -9,16 +9,17 @@ export class ArticleResolver {
 
   // getArticles Query を定義（記事一覧取得）
   @Query(() => [Article], { nullable: 'items' })
-  getArticles(): Article[] {
+  async getArticles(): Promise<Article[]> {
+    // 非同期メソッドに変更しPromise型を使用
     return this.articleService.getArticles();
   }
 
   // createArticle Mutation を定義
   @Mutation(() => Article)
-  createArticle(
-    @Args('createArticleInput') createArticleInput: CreateArticleInput,
-  ): Article {
-    const { title, url, description, tags } = createArticleInput; // 入力データを分解
-    return this.articleService.createArticle(title, url, description, tags); // 各引数に渡す
+  async createArticle(
+    @Args('createArticleInput') createArticleInput: CreateArticleInput, // 入力データ
+  ): Promise<Article> {
+    // 非同期メソッドに変更しPromise型を使用
+    return this.articleService.createArticle(createArticleInput); // CreateArticleInput型のオブジェクトを渡す
   }
 }

--- a/backend/src/article/article.service.ts
+++ b/backend/src/article/article.service.ts
@@ -1,37 +1,45 @@
 import { Injectable } from '@nestjs/common';
-import { Article } from './models/article.model';
+import { Article as ArticleModel } from './models/article.model';
+import { Article } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CreateArticleInput } from './dto/CreateArticleInput';
 
 @Injectable()
 export class ArticleService {
-  articles: Article[] = [];
-
-  // 新しい記事を作成するメソッド
-  createArticle(
-    title: string,
-    url: string,
-    description?: string,
-    tags?: string[],
-  ): Article {
-    const newArticle = new Article();
-
-    // 新しい記事のIDを自動的に付与
-    newArticle.id = this.articles.length + 1;
-    newArticle.title = title;
-    newArticle.url = url;
-    newArticle.description = description || '';
-    newArticle.tags = tags || [];
-    newArticle.createdAt = new Date();
-    newArticle.updatedAt = new Date();
-    newArticle.deletedAt = null;
-
-    // 作成した記事をarticles配列に追加
-    this.articles.push(newArticle);
-
-    return newArticle;
-  }
+  constructor(private readonly prismaService: PrismaService) {}
 
   // 記事一覧を取得するメソッド
-  getArticles(): Article[] {
-    return this.articles;
+  async getArticles(): Promise<ArticleModel[]> {
+    const articles = await this.prismaService.article.findMany();
+    return articles.map((article) => this.mapToArticleModel(article));
+  }
+
+  async createArticle(
+    createArticleInput: CreateArticleInput,
+  ): Promise<ArticleModel> {
+    const { title, url, description, tags } = createArticleInput;
+    const createdArticle = await this.prismaService.article.create({
+      data: {
+        title,
+        url,
+        description,
+        tags,
+      },
+    });
+    return this.mapToArticleModel(createdArticle);
+  }
+
+  // Prisma の Article を GraphQL の ArticleModel に変換するヘルパーメソッド
+  private mapToArticleModel(article: Article): ArticleModel {
+    return {
+      id: article.id,
+      title: article.title,
+      url: article.url,
+      description: article.description,
+      tags: article.tags,
+      createdAt: article.createdAt,
+      updatedAt: article.updatedAt,
+      deletedAt: article.deletedAt || null,
+    };
   }
 }


### PR DESCRIPTION
すでにid1は作成済み
```
mutation createArticle($createArticleInput: CreateArticleInput!) {
  createArticle(createArticleInput: $createArticleInput) {
    id
    title
    url
    description
    tags
  }
}
```

```
{
  "createArticleInput": {
    "title": "golangci-lint",
    "url": "https://qiita.com/Hashimoto-Noriaki/items/e31dc42f2fe13f67c58c",
    "description": "GitHUbActions",
    "tags": ["tag1", "tag2"]
  }
}
```

<img width="1440" alt="スクリーンショット 2024-12-07 3 44 45" src="https://github.com/user-attachments/assets/c8264630-317a-4d17-b6d8-1f09332b8a90">


- 記事の一覧取得 

```
query {
  getArticles {
    id
    title
    url
    description
    tags
    createdAt
    updatedAt
    deletedAt
  }
}
```

<img width="1439" alt="スクリーンショット 2024-12-07 3 45 09" src="https://github.com/user-attachments/assets/93ff9ef5-9513-4910-a8b7-a92af9e06da1">
